### PR TITLE
feat: returning error message from cedar.Save() from cedar.SaveToFile()

### DIFF
--- a/io.go
+++ b/io.go
@@ -32,8 +32,7 @@ func (da *Cedar) SaveToFile(fileName string, dataType string) error {
 	defer file.Close()
 	out := bufio.NewWriter(file)
 	defer out.Flush()
-	da.Save(out, dataType)
-	return nil
+	return da.Save(out, dataType)
 }
 
 // Load loads the cedar from an io.Writer,


### PR DESCRIPTION
Ran cedar.SaveToFile(fileName, "gob") and got a nil error response, but output file was empty.
I saw that the (potential) error message from cedar.Save() was ignored. Returning the output from that instead.