### PR TITLE
failing test: cedar.Save is broken 

### DIFF
--- a/cedar_test.go
+++ b/cedar_test.go
@@ -2,6 +2,7 @@ package cedar
 
 import (
 	"fmt"
+	"os"
 	"testing"
 )
 
@@ -40,4 +41,62 @@ func TestInsertFloat(t *testing.T) {
 		fmt.Printf("key:%s val:%f\n", string(k), v.(float32))
 	}
 	cd.DumpGraph("datrie.gv")
+}
+
+func TestCedar_Save(t *testing.T) {
+	cd := createCedar(t)
+	formats := []string{"json", "gob"}
+	for _, format := range formats {
+		testCedarFormat(t, cd, format)
+	}
+
+}
+
+func createCedar(t *testing.T) *Cedar {
+	t.Helper()
+	cd := NewCedar()
+	words := []string{
+		"she", "hers", "her", "he",
+	}
+	for i, word := range words {
+		cd.Insert([]byte(word), i)
+	}
+	return cd
+}
+
+func testCedarFormat(t *testing.T, cd *Cedar, format string) {
+	t.Helper()
+	fileName := "test.tmp"
+	f, err := os.Create(fileName)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer os.Remove(fileName)
+	err = cd.Save(f, format)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	cd2 := NewCedar()
+	err = cd2.LoadFromFile(fileName, format)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	keys, nodes, size, cap := cd.Status()
+	keys2, nodes2, size2, cap2 := cd2.Status()
+	if keys != keys2 {
+		t.Errorf("Had %v keys, but reloaded %s has %v", keys, format, keys2)
+	}
+	if nodes != nodes2 {
+		t.Errorf("Had %v nodes, but reloaded %s has %v", nodes, format, nodes2)
+	}
+	if size != size2 {
+		t.Errorf("Had %v size, but reloaded %s has %v", size, format, size2)
+	}
+	if cap != cap2 {
+		t.Errorf("Had %v cap, but reloaded %s has %v", cap, format, cap2)
+	}
 }

--- a/cedar_test.go
+++ b/cedar_test.go
@@ -44,16 +44,6 @@ func TestInsertFloat(t *testing.T) {
 }
 
 func TestCedar_Save(t *testing.T) {
-	cd := createCedar(t)
-	formats := []string{"json", "gob"}
-	for _, format := range formats {
-		testCedarFormat(t, cd, format)
-	}
-
-}
-
-func createCedar(t *testing.T) *Cedar {
-	t.Helper()
 	cd := NewCedar()
 	words := []string{
 		"she", "hers", "her", "he",
@@ -61,7 +51,10 @@ func createCedar(t *testing.T) *Cedar {
 	for i, word := range words {
 		cd.Insert([]byte(word), i)
 	}
-	return cd
+	formats := []string{"json", "gob"}
+	for _, format := range formats {
+		testCedarFormat(t, cd, format)
+	}
 }
 
 func testCedarFormat(t *testing.T, cd *Cedar, format string) {


### PR DESCRIPTION
Since there are no exported fields in the Cedar struct, the Save() method doesn't work. Both gob and json uses introspection, which can only see exported fields from what I understand.

I added failing test-cases. I don't know which fields are necessary, and which are more like temporary state that can be inferred. 

Thank you for this package. 